### PR TITLE
Update React, use non-deprecated way of including react addons

### DIFF
--- a/SubContainer.js
+++ b/SubContainer.js
@@ -1,5 +1,5 @@
 var s = require('react-prefixr');
-var React = require('react/addons');
+var React = require('react');
 
 var SubContainer = React.createClass({
   displayName: 'Sub-Infinity',

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var React = require('react/addons');
-var TransitionGroup = React.createFactory(React.addons.TransitionGroup);
+var React = require('react');
+var TransitionGroup = React.createFactory(require('react-addons-transition-group'));
 
 var RAFList = require('./RAFList');
 
@@ -250,7 +250,7 @@ var Infinite = React.createClass({
       console.warn('the prop `direction` must be either "vertical" or "horizontal". It is set to', this.props.direction);
       return this.vertical();
     }
-    
+
   }
 
 });

--- a/package.json
+++ b/package.json
@@ -30,10 +30,11 @@
   },
   "homepage": "https://github.com/naman34/react-infinity",
   "dependencies": {
-    "famous": "0.2.2"
+    "famous": "0.2.2",
+    "react-addons-transition-group": "^0.14.6"
   },
   "peerDependencies": {
-    "react": ">=0.12.0",
+    "react": ">=0.14.6",
     "react-prefixr": "*"
   }
 }


### PR DESCRIPTION
Are you OK with updating the React dependency to 0.14.6?

What prompted me to update the React dependency, was the deprecation warning I got due to the importing of `react/addons`, which should now be the separate package `react-addons-transition-group` instead. The latter requires React 0.14.x.
